### PR TITLE
feat: canal de venta

### DIFF
--- a/erpnext/selling/doctype/canal_de_venta/canal_de_venta.js
+++ b/erpnext/selling/doctype/canal_de_venta/canal_de_venta.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Canal de Venta', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/selling/doctype/canal_de_venta/canal_de_venta.json
+++ b/erpnext/selling/doctype/canal_de_venta/canal_de_venta.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "autoname": "field:nombre",
+ "creation": "2021-06-18 11:40:52.121964",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "nombre"
+ ],
+ "fields": [
+  {
+   "fieldname": "nombre",
+   "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Nombre",
+   "reqd": 1,
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-06-18 11:41:19.489021",
+ "modified_by": "Administrator",
+ "module": "Selling",
+ "name": "Canal de Venta",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/erpnext/selling/doctype/canal_de_venta/canal_de_venta.py
+++ b/erpnext/selling/doctype/canal_de_venta/canal_de_venta.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class CanaldeVenta(Document):
+	pass

--- a/erpnext/selling/doctype/canal_de_venta/test_canal_de_venta.py
+++ b/erpnext/selling/doctype/canal_de_venta/test_canal_de_venta.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestCanaldeVenta(unittest.TestCase):
+	pass

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -16,6 +16,7 @@
   "customer",
   "customer_name",
   "order_type",
+  "canal_de_venta",
   "skip_delivery_note",
   "column_break1",
   "amended_from",
@@ -216,6 +217,7 @@
    "default": "Sales",
    "fieldname": "order_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Order Type",
@@ -1486,13 +1488,19 @@
    "fieldname": "disable_rounded_total",
    "fieldtype": "Check",
    "label": "Disable Rounded Total"
+  },
+  {
+   "fieldname": "canal_de_venta",
+   "fieldtype": "Link",
+   "label": "Canal de Venta",
+   "options": "Canal de Venta"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-04-15 23:55:13.439068",
+ "modified": "2021-06-18 11:45:54.689704",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -13,6 +13,7 @@
   "selling_price_list",
   "close_opportunity_after_days",
   "default_valid_till",
+  "canal_de_venta",
   "column_break_5",
   "so_required",
   "dn_required",
@@ -152,6 +153,13 @@
    "fieldtype": "Link",
    "label": "Role Allowed to Override Stop Action",
    "options": "Role"
+  },
+  {
+   "fieldname": "canal_de_venta",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Canal de Venta por Defecto",
+   "options": "Canal de Venta"
   }
  ],
  "icon": "fa fa-cog",
@@ -159,7 +167,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-04-04 20:18:12.814624",
+ "modified": "2021-06-18 11:54:02.925131",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -18,7 +18,7 @@ class SellingSettings(Document):
 
 	def validate(self):
 		for key in ["cust_master_name", "campaign_naming_by", "customer_group", "territory",
-			"maintain_same_sales_rate", "editable_price_list_rate", "selling_price_list"]:
+			"maintain_same_sales_rate", "editable_price_list_rate", "selling_price_list", "canal_de_venta"]:
 				frappe.db.set_default(key, self.get(key, ""))
 
 		from erpnext.setup.doctype.naming_series.naming_series import set_by_naming_series

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -32,6 +32,7 @@ def after_install():
 	add_standard_navbar_items()
 	add_app_name()
 	add_non_standard_user_types()
+	add_canal_de_venta()
 	frappe.db.commit()
 
 
@@ -234,3 +235,9 @@ def update_select_perm_after_install():
 		doc.save()
 
 	frappe.flags.update_select_perm_after_migrate = False
+
+def add_canal_de_venta():
+	for canal in ['Sitio Web', 'Local', 'Mayorista']:
+		doc = frappe.new_doc('Canal de Venta')
+		doc.nombre = canal
+		doc.save()


### PR DESCRIPTION
### Testing

Para agregar los canales de venta que se crearan por defecto al instalar erpnext en sitios nuevos

```bash
bench --site sitename console
```

```python
from erpnext.setup.install import add_canal_de_venta

add_canal_de_venta()
frappe.db.commit()
```