### PR TITLE
Mercadolibre integration

### DIFF
--- a/erpnext/domains/mercadolibre.py
+++ b/erpnext/domains/mercadolibre.py
@@ -4,4 +4,8 @@ data = {
     'modules': [
         'Mercadolibre'
     ],
+	'restricted_roles': [
+		'Gerente de Mercadolibre',
+		'Usuario de Mercadolibre'
+	],
 }

--- a/erpnext/erpnext_integrations/doctype/amazon_mws_settings/amazon_mws_settings.json
+++ b/erpnext/erpnext_integrations/doctype/amazon_mws_settings/amazon_mws_settings.json
@@ -213,7 +213,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:51.363677",
+ "modified": "2021-10-14 14:02:04.826242",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Amazon MWS Settings",
@@ -231,7 +231,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/erpnext/erpnext_integrations/doctype/exotel_settings/exotel_settings.json
+++ b/erpnext/erpnext_integrations/doctype/exotel_settings/exotel_settings.json
@@ -40,7 +40,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:53.110774",
+ "modified": "2021-10-14 14:07:33.223862",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Exotel Settings",
@@ -58,7 +58,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "ASC",
  "track_changes": 1

--- a/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.json
+++ b/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.json
@@ -45,7 +45,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 19:59:54.039687",
+ "modified": "2021-10-14 14:05:14.895445",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "GoCardless Settings",
@@ -65,7 +65,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/erpnext/erpnext_integrations/doctype/mpesa_settings/mpesa_settings.json
+++ b/erpnext/erpnext_integrations/doctype/mpesa_settings/mpesa_settings.json
@@ -103,7 +103,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 19:59:49.817383",
+ "modified": "2021-10-14 14:06:08.737069",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Mpesa Settings",
@@ -146,7 +146,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.json
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.json
@@ -70,7 +70,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:49.562718",
+ "modified": "2021-10-14 14:06:52.823917",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Plaid Settings",
@@ -87,7 +87,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
@@ -330,7 +330,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:49.037682",
+ "modified": "2021-10-14 14:04:37.183557",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Shopify Settings",
@@ -347,7 +347,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/erpnext/erpnext_integrations/doctype/woocommerce_settings/woocommerce_settings.json
+++ b/erpnext/erpnext_integrations/doctype/woocommerce_settings/woocommerce_settings.json
@@ -154,7 +154,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:51.832961",
+ "modified": "2021-10-14 14:03:03.889389",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Woocommerce Settings",
@@ -171,7 +171,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "ERPNext Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1


### PR DESCRIPTION
## Relacionados

https://github.com/fproldan/ecommerce_integrations/issues/5

## Comentarios

Se agregan los roles requeridos para la integración de Mercadolibre de la app `ecommerce_integracion`.

Se agregó la restricción al dominio `Thrash` para los siguientes DocTypes:
- Amazon MWS Settings
- Exotel Settings
- GoCardless Settings
- Mpesa Settings
- Plaid Settings
- Shopify Settings
- Woocommerce Settings

Todos estos DocTypes estaban relacionados al Workspace `Integrations`. Con este nuevo dominio se los oculta, ya que sólo queremos mostrar los DocTypes de la integración de Mercadolibre.