### PR TITLE
perf: improve financial statement loading time

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -425,8 +425,7 @@ def set_gl_entries_by_account(
 			{additional_conditions}
 			and posting_date <= %(to_date)s
 			and is_cancelled = 0
-			{distributed_cost_center_query}
-			order by account, posting_date""".format(
+			{distributed_cost_center_query}""".format(
 				additional_conditions=additional_conditions,
 				distributed_cost_center_query=distributed_cost_center_query), gl_filters, as_dict=True) #nosec
 


### PR DESCRIPTION
Remove sorting from SQL query while fetching the ledger entries, since balances of these entries are going to be consolidated by account, later on, so sorted entries aren't necessary

This reduced the loading time of a Trial Balance report from ~18 secs to ~7secs so around 60% improvement