### PR TITLE
Obtener el precio del dolar diariamente

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -419,7 +419,8 @@ scheduler_events = {
 		"erpnext.healthcare.doctype.patient_appointment.patient_appointment.update_appointment_status",
 		"erpnext.buying.doctype.supplier_quotation.supplier_quotation.set_expired_status",
 		"erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.send_auto_email",
-		"erpnext.non_profit.doctype.membership.membership.set_expired_status"
+		"erpnext.non_profit.doctype.membership.membership.set_expired_status",
+		"erpnext.setup.doctype.currency_exchange.currency_exchange.set_currency_exchange_rates",
 	],
 	"daily_long": [
 		"erpnext.setup.doctype.email_digest.email_digest.send",

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -60,7 +60,7 @@ def get_currency_exchange_rate(from_currency: str, to_currency: str) -> Optional
 
 
 def set_currency_exchange_rates(*args, **kwargs):
-	for currency_pair in list(
+	for currency_pair in tuple(
 		itertools.product(
 			("ARS",), get_all("Currency", {"exchange_rate_type": ("!=", "")}, pluck="name")
 		)

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -43,11 +43,11 @@ def get_currency_exchange_rate(from_currency: str, to_currency: str) -> Optional
 	if from_currency == "ARS" and to_currency == "USD":
 		for data in requests.get("https://www.dolarsi.com/api/api.php?type=valoresprincipales").json():
 			if data["casa"]["nombre"] == "Dolar Oficial":
-				return float(data["casa"]["venta"].replace(",", "."))
+				return 1 / float(data["casa"]["venta"].replace(",", "."))
 	if from_currency == "USD" and to_currency == "ARS":
 		for data in requests.get("https://www.dolarsi.com/api/api.php?type=valoresprincipales").json():
 			if data["casa"]["nombre"] == "Dolar Oficial":
-				return 1 / float(data["casa"]["compra"].replace(",", "."))
+				return float(data["casa"]["compra"].replace(",", "."))
 	return None
 
 

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -43,11 +43,11 @@ def get_currency_exchange_rate(from_currency: str, to_currency: str) -> Optional
 	if from_currency == "ARS" and to_currency == "USD":
 		for data in requests.get("https://www.dolarsi.com/api/api.php?type=valoresprincipales").json():
 			if data["casa"]["nombre"] == "Dolar Oficial":
-				return float(data["casa"]["venta"].replace(',', '.'))
+				return float(data["casa"]["venta"].replace(",", "."))
 	if from_currency == "USD" and to_currency == "ARS":
 		for data in requests.get("https://www.dolarsi.com/api/api.php?type=valoresprincipales").json():
 			if data["casa"]["nombre"] == "Dolar Oficial":
-				return 1 / float(data["casa"]["compra"].replace(',', '.'))
+				return 1 / float(data["casa"]["compra"].replace(",", "."))
 	return None
 
 


### PR DESCRIPTION
## Relacionados

https://github.com/fproldan/DiamoERP/issues/223

## Comentarios

Este PR permite sincronizar automáticamente, todos los días, el tipo de cambio entre una moneda cualquiera y el peso argentino.
Para que esto ocurra, primero hay que ir a la vista de la moneda que se quiere sincronizar y seleccionar un "Tipo de dólar" (campo nuevo).

Hay varias opciones:
```
Dolar Oficial
Dolar Blue
Dolar Contado con Liqui
Dolar Bolsa
```
Si se deja vacío no se sincroniza.

:rotating_light: **Importante:**
- Este campo aparece en cualquier moneda, incluso en los euros. Beneficio? Que alguien puede crear varias monedas de dolar y a cada una ponerle un tipo de cambio diferente. Ejemplo: puede crear la moneda USD-O para el dolar oficial y la moneda USD-CCL para el contado con liqui.
- Esto no funciona si se edita el nombre de la moneda **ARS**.
- Si a la moneda **ARS** se le selecciona un tipo de dolar, se genera una excepción al correr la lógica.

## Testing

Para ejecutar manualmente esta lógica y no tener que esperar, se puede correr el siguiente comando:
```sh
bench execute erpnext.setup.doctype.currency_exchange.currency_exchange.set_currency_exchange_rates
```


