### PR TITLE
Problema con descuentos en FV

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -376,11 +376,11 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 					me.set_in_company_currency(tax, ["total"]);
 
 					// adjust Discount Amount loss in last tax iteration
-					if ((i == me.frm.doc["taxes"].length - 1) && me.discount_amount_applied
-						&& me.frm.doc.apply_discount_on == "Grand Total" && me.frm.doc.discount_amount) {
-						me.frm.doc.rounding_adjustment = flt(me.frm.doc.grand_total -
-							flt(me.frm.doc.discount_amount) - tax.total, precision("rounding_adjustment"));
-					}
+					// if ((i == me.frm.doc["taxes"].length - 1) && me.discount_amount_applied
+					// 	&& me.frm.doc.apply_discount_on == "Grand Total" && me.frm.doc.discount_amount) {
+					// 	me.frm.doc.rounding_adjustment = flt(me.frm.doc.grand_total -
+					// 		flt(me.frm.doc.discount_amount) - tax.total, precision("rounding_adjustment"));
+					// }
 				}
 			});
 		});


### PR DESCRIPTION
https://github.com/fproldan/DiamoERP/issues/586

No le pude encontrar la vuelta, hay un codigo que explicitamente cuando hay taxes y descuento sobre "Grand Total" hace un calculo y ese numero (que es igual al monto del descuento se ve) lo aplica en Ajuste de Redondeo provocando que quede duplicado luego el Monto pendiente.

Probando en un v13 actualizado no lo pude reproducir aunque el codigo de esa parte sea exactamente igual. No se si el problema lo introdujimos nosotros con nuestra app erpnext_argentina o hay otra parte del codigo de nuestro ERPNext mas viejo que introduce el problema.

Por ahora opte por comentar directamente esa parte, desconozco si puede traernos algun otro problema. 