### PR TITLE
Balance Multimoneda Ticket-01245 

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.json
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.json
@@ -32,7 +32,11 @@
   "finance_book",
   "to_rename",
   "due_date",
-  "is_cancelled"
+  "is_cancelled",
+  "transaction_currency",
+  "debit_in_transaction_currency",
+  "credit_in_transaction_currency",
+  "transaction_exchange_rate"
  ],
  "fields": [
   {
@@ -253,13 +257,36 @@
    "fieldname": "is_cancelled",
    "fieldtype": "Check",
    "label": "Is Cancelled"
+  },
+  {
+   "fieldname": "transaction_currency",
+   "fieldtype": "Link",
+   "label": "Moneda de la Transacción",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "transaction_exchange_rate",
+   "fieldtype": "Float",
+   "label": "Tipo de cambio de la Transacción "
+  },
+  {
+   "fieldname": "debit_in_transaction_currency",
+   "fieldtype": "Currency",
+   "label": "Importe del Débito en la moneda de la transacción",
+   "options": "transaction_currency"
+  },
+  {
+   "fieldname": "credit_in_transaction_currency",
+   "fieldtype": "Currency",
+   "label": "Importe del Crédito en la moneda de la transacción",
+   "options": "transaction_currency"
   }
  ],
  "icon": "fa fa-list",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2022-12-16 09:47:01.613106",
+ "modified": "2022-12-17 10:47:01.613106",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "GL Entry",

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -193,6 +193,11 @@ frappe.query_reports["General Ledger"] = {
 			"fieldname": "excluir_asientos_ajuste_inflacion",
 			"label": __("Excluir asientos de Ajuste por Inflación"),
 			"fieldtype": "Check"
+		},
+		{
+			"fieldname": "add_values_in_transaction_currency",
+			"label": __("Añadir columnas en la moneda de la transacción"),
+			"fieldtype": "Check"
 		}
 	]
 }

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -63,12 +63,10 @@ def get_rate_as_at(date, from_currency, to_currency):
 	:param to_currency: Quote currency
 	:return: Retrieved exchange rate
 	"""
-
 	rate = __exchange_rates.get('{0}-{1}@{2}'.format(from_currency, to_currency, date))
 	if not rate:
 		rate = get_exchange_rate(from_currency, to_currency, date) or 1
 		__exchange_rates['{0}-{1}@{2}'.format(from_currency, to_currency, date)] = rate
-
 	return rate
 
 def convert_to_presentation_currency(gl_entries, currency_info, company):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -565,7 +565,27 @@ class AccountsController(TransactionBase):
 			set_balance_in_account_currency(gl_dict, account_currency, self.get("conversion_rate"),
 											self.company_currency)
 
+		# Update details in transaction currency
+		gl_dict.update(
+			{
+				"transaction_currency": self.get("currency") or self.company_currency,
+				"transaction_exchange_rate": self.get("conversion_rate", 1),
+				"debit_in_transaction_currency": self.get_value_in_transaction_currency(
+					account_currency, args, "debit"
+				),
+				"credit_in_transaction_currency": self.get_value_in_transaction_currency(
+					account_currency, args, "credit"
+				),
+			}
+		)
+
 		return gl_dict
+
+	def get_value_in_transaction_currency(self, account_currency, args, field):
+		if account_currency == self.get("currency"):
+			return args.get(field + "_in_account_currency")
+		else:
+			return flt(args.get(field, 0) / self.get("conversion_rate", 1))
 
 	def validate_qty_is_not_zero(self):
 		if self.doctype != "Purchase Receipt":

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -365,4 +365,3 @@ erpnext.patches.v13_0.release_1_7
 erpnext.patches.v13_0.remove_auditor_role_from_users
 erpnext.patches.v13_0.remove_old_hr_domains
 erpnext.patches.v13_0.release_1_8
-erpnext.patches.v13_0.add_values_in_transaction_currency

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -365,3 +365,4 @@ erpnext.patches.v13_0.release_1_7
 erpnext.patches.v13_0.remove_auditor_role_from_users
 erpnext.patches.v13_0.remove_old_hr_domains
 erpnext.patches.v13_0.release_1_8
+erpnext.patches.v13_0.add_values_in_transaction_currency

--- a/erpnext/patches/v13_0/add_values_in_transaction_currency.py
+++ b/erpnext/patches/v13_0/add_values_in_transaction_currency.py
@@ -3,11 +3,6 @@
 import frappe
 from frappe.utils import flt
 from erpnext.accounts.utils import get_account_currency
-import erpnext.hooks as hooks
-
-
-def execute():
-    hooks.after_migrate.append("erpnext.patches.v13_0.add_values_in_transaction_currency.add_values_in_transaction_currency")
 
 
 def add_values_in_transaction_currency():

--- a/erpnext/patches/v13_0/add_values_in_transaction_currency.py
+++ b/erpnext/patches/v13_0/add_values_in_transaction_currency.py
@@ -1,0 +1,35 @@
+# Copyright(c) 2020, Frappe Technologies Pvt.Ltd.and Contributors
+# License: GNU General Public License v3.See license.txt
+import frappe
+from frappe.utils import flt
+from erpnext.accounts.utils import get_account_currency
+import erpnext.hooks as hooks
+
+
+def execute():
+    hooks.after_migrate.append("erpnext.patches.v13_0.add_values_in_transaction_currency.add_values_in_transaction_currency")
+
+
+def add_values_in_transaction_currency():
+    for gl_entry in frappe.get_all('GL Entry', pluck='name'):
+        gl_entry = frappe.get_doc('GL Entry', gl_entry)
+        if not frappe.db.exists(gl_entry.voucher_type, gl_entry.voucher_no):
+            continue
+        doc = frappe.get_doc(gl_entry.voucher_type, gl_entry.voucher_no)
+        account_currency = get_account_currency(gl_entry.account)
+        data = {
+            "transaction_currency": doc.get("currency") or doc.company_currency,
+            "transaction_exchange_rate": doc.get("conversion_rate", 1),
+            "debit_in_transaction_currency": get_value_in_transaction_currency(doc, gl_entry, account_currency, "debit"),
+            "credit_in_transaction_currency": get_value_in_transaction_currency(doc, gl_entry, account_currency, "credit"),
+		}
+        for key, value in data.items():
+            frappe.db.set_value('GL Entry', gl_entry.name, key, value)
+        frappe.db.commit()
+
+
+def get_value_in_transaction_currency(doc, gl_entry, account_currency, field):
+    if account_currency == doc.get("currency"):
+        return gl_entry.get(field + "_in_account_currency")
+    else:
+        return flt(gl_entry.get(field, 0) / doc.get("conversion_rate", 1))


### PR DESCRIPTION
https://github.com/fproldan/DiamoERP/issues/620

- Si se tilda la opción "Añadir columnas en la moneda de transacción" se va a poder ver el valor en la moneda original de la transacción tomando el tipo de cambio de la fecha de la misma (lo toma del `conversion_rate` del documento, en este ejemplo 200)
![Captura de pantalla 2023-10-17 a la(s) 10 03 51](https://github.com/fproldan/erpnext/assets/4945122/58e1a6b5-d091-4488-aab3-d2a2a886089a)

![Captura de pantalla 2023-10-17 a la(s) 10 04 34](https://github.com/fproldan/erpnext/assets/4945122/1927059c-52df-4d89-9e34-c48da9cddfbb)

- Acá se puede ver la diferencia de valores al cambiar la moneda a USD, se puede ver que muestra al tipo de cambio del dia (800 en este caso) comparado con el valor en la fecha de la transacción.
![Captura de pantalla 2023-10-17 a la(s) 10 11 51](https://github.com/fproldan/erpnext/assets/4945122/94b0e65a-4e16-454f-8638-0a7c06c0e844)



**Se va a correr un parche, hay que probarlo con una base de datos de clientes porque puede llegar a demorar mucho, en todo caso se correra a mano en el cliente necesario.**


