### PR TITLE
Selectores múltiples o de padres en Stock Proyectado

### DIFF
--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
@@ -37,8 +37,11 @@ frappe.query_reports["Stock Projected Qty"] = {
 		{
 			"fieldname":"item_group",
 			"label": __("Item Group"),
-			"fieldtype": "Link",
-			"options": "Item Group"
+			"fieldtype": 'MultiSelectList',
+			"options": "Item Group",
+			"get_data": function (txt) {
+				return frappe.db.get_link_options('Item Group', txt, {})
+			},
 		},
 		{
 			"fieldname":"brand",

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
@@ -13,15 +13,13 @@ frappe.query_reports["Stock Projected Qty"] = {
 		{
 			"fieldname":"warehouse",
 			"label": __("Warehouse"),
-			"fieldtype": "Link",
+			"fieldtype": "MultiSelectList",
 			"options": "Warehouse",
-			"get_query": () => {
-				return {
-					filters: {
-						company: frappe.query_report.get_filter_value('company')
-					}
-				}
-			}
+			"get_data": function (txt) {
+				return frappe.db.get_link_options('Warehouse', txt, {
+					company: frappe.query_report.get_filter_value('company'),
+				})
+			},
 		},
 		{
 			"fieldname":"item_code",

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -111,17 +111,18 @@ def get_bin_list(filters):
 		conditions.append("item_code = '%s' "%filters.item_code)
 
 	if filters.warehouse:
-		warehouse_details = frappe.db.get_value("Warehouse", filters.warehouse, ["lft", "rgt"], as_dict=1)
+		for warehouse in filters.warehouse:
+			warehouse_details = frappe.db.get_value("Warehouse", warehouse, ["lft", "rgt"], as_dict=1)
 
-		if warehouse_details:
-			conditions.append(" exists (select name from `tabWarehouse` wh \
-				where wh.lft >= %s and wh.rgt <= %s and bin.warehouse = wh.name)"%(warehouse_details.lft,
-				warehouse_details.rgt))
+			if warehouse_details:
+				conditions.append(" exists (select name from `tabWarehouse` wh \
+					where wh.lft >= %s and wh.rgt <= %s and bin.warehouse = wh.name)"%(warehouse_details.lft,
+					warehouse_details.rgt))
 
 	bin_list = frappe.db.sql("""select item_code, warehouse, actual_qty, planned_qty, indented_qty,
 		ordered_qty, reserved_qty, reserved_qty_for_production, reserved_qty_for_sub_contract, projected_qty
 		from tabBin bin {conditions} order by item_code, warehouse
-		""".format(conditions=" where " + " and ".join(conditions) if conditions else ""), as_dict=1)
+		""".format(conditions=" where " + " or ".join(conditions) if conditions else ""), as_dict=1)
 
 	return bin_list
 

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import flt, today
+from frappe.utils.nestedset import get_descendants_of
 
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import get_pos_reserved_qty
 from erpnext.stock.utils import (
@@ -39,8 +40,14 @@ def execute(filters=None):
 		if filters.brand and filters.brand != item.brand:
 			continue
 
-		elif filters.item_group and filters.item_group != item.item_group:
-			continue
+		if filters.item_group:
+			item_group_descendants = []
+			for item_group in filters.item_group:
+				item_group_descendants += get_descendants_of("Item Group", item_group)
+				item_group_descendants.append(item_group)
+			
+			if item.item_group not in item_group_descendants:
+				continue
 
 		elif filters.company and filters.company != company:
 			continue

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -41,12 +41,7 @@ def execute(filters=None):
 			continue
 
 		if filters.item_group:
-			item_group_descendants = []
-			for item_group in filters.item_group:
-				item_group_descendants += get_descendants_of("Item Group", item_group)
-				item_group_descendants.append(item_group)
-			
-			if item.item_group not in item_group_descendants:
+			if item.item_group not in filters.item_group:
 				continue
 
 		elif filters.company and filters.company != company:


### PR DESCRIPTION
https://github.com/fproldan/DiamoERP/issues/602

## Comportamiento original

- Permitia seleccionar un solo Grupo de Productos.
- Si se seleccionaba un Grupo de Producto "Padre" solo filtraba por los productos que tenian ese grupo y no por los que tienen un grupo de producto descendiente.

- Permitia seleccionar un solo almacen.


## Comportamiento con este PR
- Permite seleccionar multiples Grupo de Productos.

- Permite seleccionar multiples almacenes.
