### PR TITLE
Auto asignación de Vendedor

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -85,15 +85,21 @@ def _get_party_details(party=None, account=None, party_type="Customer", company=
 
 	# sales team
 	if party_type=="Customer":
-		party_details["sales_team"] = [{
-			"sales_person": d.sales_person,
-			"allocated_percentage": d.allocated_percentage or None
-		} for d in party.get("sales_team")] + [
-			{
+		sales_persons = []
+		party_details["sales_team"] = []
+		for d in party.get("sales_team"):
+			sales_persons.append(d.sales_person)
+			party_details["sales_team"].append({
+				"sales_person": d.sales_person,
+				"allocated_percentage": d.allocated_percentage or None
+			})
+
+		for d in frappe.get_all("Sales Person", {"user": frappe.session.user}, pluck="name"):
+			if d not in sales_persons:
+				party_details["sales_team"].append({
 				"sales_person":d,
 				"allocated_percentage":  100
-			} for d in frappe.get_all("Sales Person", {"user": frappe.session.user}, pluck="name")
-		]
+			})
 
 	# supplier tax withholding category
 	if party_type == "Supplier" and party:

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -88,7 +88,12 @@ def _get_party_details(party=None, account=None, party_type="Customer", company=
 		party_details["sales_team"] = [{
 			"sales_person": d.sales_person,
 			"allocated_percentage": d.allocated_percentage or None
-		} for d in party.get("sales_team")]
+		} for d in party.get("sales_team")] + [
+			{
+				"sales_person":d,
+				"allocated_percentage":  100
+			} for d in frappe.get_all("Sales Person", {"user": frappe.session.user}, pluck="name")
+		]
 
 	# supplier tax withholding category
 	if party_type == "Supplier" and party:

--- a/erpnext/setup/doctype/sales_person/sales_person.js
+++ b/erpnext/setup/doctype/sales_person/sales_person.js
@@ -19,6 +19,15 @@ frappe.ui.form.on('Sales Person', {
 			}
 		};
 
+		frm.set_query("user", function(doc) {
+			return {
+				filters: {
+					"enabled": 1,
+					"user_type": "System User"
+				}
+			};
+		});
+
 		frm.make_methods = {
 			'Sales Order': () => frappe.new_doc("Sales Order")
 				.then(() => frm.add_child("sales_team", {"sales_person": frm.doc.name}))

--- a/erpnext/setup/doctype/sales_person/sales_person.json
+++ b/erpnext/setup/doctype/sales_person/sales_person.json
@@ -17,6 +17,7 @@
   "enabled",
   "cb0",
   "employee",
+  "user",
   "department",
   "lft",
   "rgt",
@@ -139,13 +140,20 @@
    "oldfieldname": "target_details",
    "oldfieldtype": "Table",
    "options": "Target Detail"
+  },
+  {
+   "description": "Esto autoasignar\u00e1 al vendedor en las transacci\u00f3nes",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User"
   }
  ],
  "icon": "icon-user",
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2021-05-13 21:02:44.461588",
+ "modified": "2024-08-16 10:34:56.363159",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Sales Person",


### PR DESCRIPTION
https://github.com/fproldan/DiamoERP/issues/467


### Nuevo campo en Vendedor

![Captura de pantalla 2024-08-16 a la(s) 10 39 46 a  m](https://github.com/user-attachments/assets/43b23dc3-13c0-44bb-9297-b7b15eb7b4fb)


### Asignacion

<img width="1297" alt="Captura de pantalla 2024-08-16 a la(s) 11 17 40 a  m" src="https://github.com/user-attachments/assets/f30cec61-d6f8-4969-82ea-edf4d1548948">

- Cuando existe algun vendedor con el campo `usuario` con el valor del usuario logeado, se agrega el vendedor a la lista de Equipo de Ventas. Esto se dispara al seleccionar el cliente que es el mecanismo que ya existe para traer los vendedores configurados en el Cliente.
- El margen que le ponemos es 100% por lo que si el Cliente tiene configurado un equipo de venta por defecto va a darle un mensaje de error por los porcentajes pero creo que no esta mal, solamente en ese caso tienen que editar los porcentajes.